### PR TITLE
Node modules importer

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 /docs
 /.travis.yml
+/importer.js

--- a/importer.js
+++ b/importer.js
@@ -1,0 +1,10 @@
+var NODE_MODULE_IDENTIFIER = /^~[^/]/
+
+// node-sass importer, replicates sass-loader for webpack;
+// when match is found: rewrite the url to "../node_modules/".
+// See: https://github.com/sass/node-sass#importer--v200---experimental
+// See: https://github.com/webpack-contrib/sass-loader#imports
+module.exports = function importer (url) {
+  if (NODE_MODULE_IDENTIFIER.exec(url)) url = '../node_modules/' + url.slice(1)
+  return {'file': url}
+}

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 scss/style.scss dist/add-style.css",
-    "build-docs": "node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 docs/style.scss docs/style.css",
+    "build": "node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 --importer importer.js scss/style.scss dist/add-style.css",
+    "build-docs": "node-sass --output-style expanded --source-map true --source-map-contents true --precision 6 --importer importer.js docs/style.scss docs/style.css",
     "watch": "nodemon --watch scss --ignore dist/ -e scss -x \"npm run build\""
   }
 }

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -1,6 +1,7 @@
 @import "variables";
 
-@import "../node_modules/bootstrap/scss/bootstrap";
+// ~ is used by Webpack to identify a node module, see importer.js
+@import "~bootstrap/scss/bootstrap";
 
 @import "mixins";
 @import "custom";


### PR DESCRIPTION
Added custom node-sass importer to resolve node modules.

In order to use the package with webpack's sass-loader a sass import like the one below is required:
```scss
@import "~bootstrap/scss/bootstrap";
```

`node-sass` (for local builds) does not know this `~` syntax. The new `importer.js` file provides `sass-loader`-like resolution to `../node_modules/`

Updated `package.json`'s `build` and `build-docs` scripts.

See:
- https://github.com/sass/node-sass#importer--v200---experimental
- https://github.com/webpack-contrib/sass-loader#imports